### PR TITLE
feat: Add docker files and docker-compose

### DIFF
--- a/arcane-mf/Dockerfile
+++ b/arcane-mf/Dockerfile
@@ -1,0 +1,27 @@
+# Dockerfile para arcane-mf
+FROM node:20-alpine AS builder
+
+# Habilita corepack y pnpm
+RUN corepack enable && corepack prepare pnpm@8.15.5 --activate
+
+WORKDIR /app
+
+# Copia solo los archivos de dependencias primero (mejor caché)
+COPY package.json pnpm-lock.yaml ./
+
+# Instala dependencias
+RUN pnpm install --frozen-lockfile
+
+# Copia el resto del código
+COPY . .
+
+# Build de la app
+RUN pnpm build
+
+FROM node:20-alpine AS runner
+WORKDIR /app
+COPY --from=builder /app/dist ./dist
+COPY --from=builder /app/package.json ./
+COPY --from=builder /app/node_modules ./node_modules
+EXPOSE 3001
+CMD ["pnpm", "preview", "--host", "0.0.0.0", "--port", "3001"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+services:
+  host-app:
+    build: ./host-app
+    ports:
+      - "3000:3000"
+    depends_on:
+      - arcane-mf
+      - tlou-mf
+  arcane-mf:
+    build: ./arcane-mf
+    ports:
+      - "3001:3001"
+  tlou-mf:
+    build: ./tlou-mf
+    ports:
+      - "3002:3002"

--- a/host-app/Dockerfile
+++ b/host-app/Dockerfile
@@ -1,0 +1,13 @@
+# Dockerfile para host-app
+FROM node:20-alpine AS builder
+WORKDIR /app
+COPY . .
+RUN npm install -g pnpm && pnpm install && pnpm build
+
+FROM node:20-alpine AS runner
+WORKDIR /app
+COPY --from=builder /app/dist ./dist
+COPY --from=builder /app/package.json ./
+COPY --from=builder /app/node_modules ./node_modules
+EXPOSE 3000
+CMD ["pnpm", "preview", "--host", "0.0.0.0", "--port", "3000"]

--- a/tlou-mf/Dockerfile
+++ b/tlou-mf/Dockerfile
@@ -1,0 +1,27 @@
+# Dockerfile para tlou-mf
+FROM node:20-alpine AS builder
+
+# Habilita corepack y pnpm
+RUN corepack enable && corepack prepare pnpm@8.15.5 --activate
+
+WORKDIR /app
+
+# Copia solo los archivos de dependencias primero (mejor caché)
+COPY package.json pnpm-lock.yaml ./
+
+# Instala dependencias
+RUN pnpm install --frozen-lockfile
+
+# Copia el resto del código
+COPY . .
+
+# Build de la app
+RUN pnpm build
+
+FROM node:20-alpine AS runner
+WORKDIR /app
+COPY --from=builder /app/dist ./dist
+COPY --from=builder /app/package.json ./
+COPY --from=builder /app/node_modules ./node_modules
+EXPOSE 3002
+CMD ["pnpm", "preview", "--host", "0.0.0.0", "--port", "3002"]


### PR DESCRIPTION
This pull request includes the addition of Dockerfiles for three microservices and a `docker-compose.yml` file to orchestrate them. The changes aim to containerize the applications and set up a multi-service environment.

Dockerfile additions:

* [`arcane-mf/Dockerfile`](diffhunk://#diff-4acede3929fb0e059c912f400466956aa197149f12a6218429eb216ea5b1434aR1-R27): Added a Dockerfile to build and run the `arcane-mf` microservice using Node.js and pnpm.
* [`host-app/Dockerfile`](diffhunk://#diff-ae992aa74df18ce054a608b89613c43988248214eaeeb416d438474cb3764340R1-R13): Added a Dockerfile to build and run the `host-app` microservice using Node.js and pnpm.
* [`tlou-mf/Dockerfile`](diffhunk://#diff-fd124af2661af690a444f868fc9385f2f66e7a358067a25c22a788e70244b4f8R1-R27): Added a Dockerfile to build and run the `tlou-mf` microservice using Node.js and pnpm.

Docker Compose setup:

* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R1-R16): Added a `docker-compose.yml` file to define and orchestrate the `host-app`, `arcane-mf`, and `tlou-mf` services, specifying build contexts, ports, and dependencies.