### PR TITLE
feat: Implement language context

### DIFF
--- a/host-app/src/context/LanguageContext.tsx
+++ b/host-app/src/context/LanguageContext.tsx
@@ -1,0 +1,21 @@
+import { createContext, ReactNode, useState } from 'react';
+
+export type Language = 'en' | 'es';
+
+interface LanguageContextProps {
+  language: Language;
+  setLanguage: (lang: Language) => void;
+}
+
+export const LanguageContext = createContext<LanguageContextProps | undefined>(undefined);
+
+export const LanguageProvider = ({ children }: { children: ReactNode }) => {
+  const [language, setLanguage] = useState<Language>('en');
+  return (
+    <LanguageContext.Provider value={{ language, setLanguage }}>
+      {children}
+    </LanguageContext.Provider>
+  );
+};
+
+

--- a/host-app/src/hooks/useLanguage.ts
+++ b/host-app/src/hooks/useLanguage.ts
@@ -1,0 +1,8 @@
+import { useContext } from "react";
+import { LanguageContext } from "../context/LanguageContext";
+
+export const useLanguage = () => {
+    const context = useContext(LanguageContext);
+    if (!context) throw new Error('useLanguage must be used within LanguageProvider');
+    return context;
+};

--- a/host-app/src/i18n/texts.ts
+++ b/host-app/src/i18n/texts.ts
@@ -1,0 +1,14 @@
+export const texts = {
+  en: {
+    selectSeries: 'Select a series',
+    arcane: 'Arcane',
+    tlou: 'The Last of Us',
+    language: 'Language',
+  },
+  es: {
+    selectSeries: 'Selecciona una serie',
+    arcane: 'Arcane',
+    tlou: 'The Last of Us',
+    language: 'Idioma',
+  },
+};


### PR DESCRIPTION
This pull request introduces a new language context and hook to manage the application's language settings, along with the addition of multilingual text support. The most important changes include the creation of a language context, a custom hook for accessing the language context, and the addition of text translations.

Context and hooks for language management:

* [`host-app/src/context/LanguageContext.tsx`](diffhunk://#diff-84636f2217405c9fc899c2df26484bc39037f6c63c1c242761911f9e892f4460R1-R21): Created a `LanguageContext` with a `LanguageProvider` component to manage the application's language state.
* [`host-app/src/hooks/useLanguage.ts`](diffhunk://#diff-d976251727accf8caf6f08a606e98d5608212791794207dd300f4573c1db7310R1-R8): Added a custom hook `useLanguage` to access the `LanguageContext` and ensure it is used within the `LanguageProvider`.

Multilingual text support:

* [`host-app/src/i18n/texts.ts`](diffhunk://#diff-f30d79d5efdd31a67249627b0db3a94b6a684aa8ee1d0fd72f5cf6bb866a3cabR1-R14): Added text translations for English and Spanish, including keys for selecting a series, and language labels.